### PR TITLE
Update to Elixir 1.17.0-rc.0 and Erlang 27.0.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Update the VARIANT arg in docker-compose.yml to pick an Elixir version: 1.9, 1.10, 1.10.4
-ARG VARIANT="1.16.3"
+ARG VARIANT="1.17.0-rc.0"
 FROM elixir:${VARIANT}
 
 # This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   elixir:
     build:
@@ -7,7 +5,7 @@ services:
       dockerfile: Dockerfile
       args:
         # Elixir Version: 1.9, 1.10, 1.10.4, ...
-        VARIANT: '1.16.3'
+        VARIANT: '1.17.0-rc.0'
         # Phoenix Version: 1.4.17, 1.5.4, ...
         PHOENIX_VERSION: '1.7.12'
         # Node Version: 12, 14, ...
@@ -22,7 +20,7 @@ services:
     command: sleep infinity
 
   db:
-    image: postgres:15.4-bullseye
+    image: postgres:16.3-bullseye
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.16.3-otp-26
-erlang 26.2.5
+elixir 1.17.0-rc.0-otp-27
+erlang 27.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@
 #   - Ex: hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim
 #
 
-ARG ELIXIR_VERSION=1.16.3
-ARG OTP_VERSION=26.2.5
+ARG ELIXIR_VERSION=1.17.0-rc.0
+ARG OTP_VERSION=27.0
 ARG DEBIAN_VERSION=bullseye-20240513-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Hasher.MixProject do
     [
       app: :hasher,
       version: "0.2.0",
-      elixir: "~> 1.16.2",
+      elixir: "~> 1.17.0-rc.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
This PR supports the following features:

- update to Erlang 27.0

- update to Elixir 1.17.0-rc.0